### PR TITLE
Remove compiler warnings for ESP32

### DIFF
--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -242,15 +242,11 @@ void QuickEspNow::espnowTxHandle () {
 void QuickEspNow::enableTransmit (bool enable) {
     DEBUG_DBG (QESPNOW_TAG, "Send esp-now task %s", enable ? "enabled" : "disabled");
     if (enable) {
-        if (espnowTxTask_cb) {
-            vTaskResume (espnowTxTask);
-            vTaskResume (espnowRxTask);
-        }
+        vTaskResume (espnowTxTask);
+        vTaskResume (espnowRxTask);
     } else {
-        if (espnowTxTask_cb) {
-            vTaskSuspend (espnowTxTask);
-            vTaskSuspend (espnowRxTask);
-        }
+        vTaskSuspend (espnowTxTask);
+        vTaskSuspend (espnowRxTask);
     }
 }
 
@@ -405,7 +401,7 @@ uint8_t PeerListClass::get_peer_number () {
 }
 
 bool PeerListClass::peer_exists (const uint8_t* mac) {
-    for (uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
+    for (int i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
         if (memcmp (peer_list.peer[i].mac, mac, ESP_NOW_ETH_ALEN) == 0) {
             if (peer_list.peer[i].active) {
                 peer_list.peer[i].last_msg = millis ();
@@ -418,7 +414,7 @@ bool PeerListClass::peer_exists (const uint8_t* mac) {
 }
 
 peer_t* PeerListClass::get_peer (const uint8_t* mac) {
-    for (uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
+    for (int i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
         if (memcmp (peer_list.peer[i].mac, mac, ESP_NOW_ETH_ALEN) == 0) {
             if (peer_list.peer[i].active) {
                 DEBUG_VERBOSE (PEERLIST_TAG, "Peer " MACSTR " found", MAC2STR (mac));
@@ -439,7 +435,7 @@ bool PeerListClass::update_peer_use (const uint8_t* mac) {
 }
 
 bool PeerListClass::add_peer (const uint8_t* mac) {
-    if (int i = peer_exists (mac)) {
+    if (peer_exists (mac)) {
         DEBUG_VERBOSE (PEERLIST_TAG, "Peer " MACSTR " already exists", MAC2STR (mac));
         return false;
     }
@@ -452,7 +448,7 @@ bool PeerListClass::add_peer (const uint8_t* mac) {
         // delete_peer (); // Delete should happen in higher level
     }
 
-    for (uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
+    for (int i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
         if (!peer_list.peer[i].active) {
             memcpy (peer_list.peer[i].mac, mac, ESP_NOW_ETH_ALEN);
             peer_list.peer[i].active = true;


### PR DESCRIPTION
Using `if (espnowTxTask_cb)` will always yield `true` as the function exists.

Also changed counter type in `for` loops from `uint8_t` to `int` to optimise for size and speed.