### PR TITLE
Fix a bug where the espnow peer list gets out of sync with the maintained PeerListClass.

### DIFF
--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -266,7 +266,15 @@ bool QuickEspNow::addPeer (const uint8_t* peer_addr) {
 
     if (peer_list.peer_exists (peer_addr)) {
         DEBUG_VERBOSE (QESPNOW_TAG, "Peer already exists");
-        ESP_ERROR_CHECK (esp_now_get_peer (peer_addr, &peer));
+
+        error = esp_now_get_peer (peer_addr, &peer);
+        if (error == ESP_ERR_ESPNOW_NOT_FOUND) {
+          peer_list.delete_peer (peer_addr);
+          DEBUG_ERROR (QESPNOW_TAG, "Peer not found. Adding again");
+          return addPeer(peer_addr);
+        } else if (error != ESP_OK) {
+          ESP_ERROR_CHECK (error);
+        }
 
         uint8_t currentChannel = peer.channel;
         DEBUG_DBG (QESPNOW_TAG, "Peer " MACSTR " is using channel %d", MAC2STR (peer_addr), currentChannel);


### PR DESCRIPTION
Fixes an issue with stopping and starting quickespnow. 

I suspect it's mentioned here: https://github.com/gmag11/QuickESPNow/issues/19#issuecomment-2849384368

Personally, I'm experiencing an issue where when you stop espnow in order to enter light sleep and then resume espnow after waking back up, when you attempt to send a message to a peer that you've talked to before, an exception is thrown and the system reboots. 

I think it'd be more beneficial to remove all peers with a call to quickespnow stop, however with message encryption perhaps that would throw a wrench into things. 